### PR TITLE
This minor change fixes an issue when using Prototype 1.7

### DIFF
--- a/prototype/iphone-style-checkboxes.js
+++ b/prototype/iphone-style-checkboxes.js
@@ -54,7 +54,7 @@ var iPhoneStyle = function(selector_or_elems, options) {
 
     elem.change = function() {
       var is_onstate = elem.checked;
-      var p = handle.positionedOffset().first() / rightside;
+      var p = handle.positionedOffset()[0] / rightside;
       new Effect.Tween(null, p, Number(is_onstate), { duration: options.duration / 1000 }, function(p) {
         handle.setStyle({ left: p * rightside + 'px' });
         onlabel.setStyle({ width: p * rightside + 4 + 'px' });


### PR DESCRIPTION
- This does not break Prototype 1.6 functionality, afaik.

I was getting a "no method named 'first'" error, but since it's an array, we can simply use the [0] operation to get the first element.
