### PR TITLE
Addressing display issue for -webkit-overflow-scroll-touch.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
 .iPhoneCheckContainer {
+  -webkit-transform:translate3d(0,0,0);
   position: relative;
   height: 27px;
   cursor: pointer;


### PR DESCRIPTION
Added a webkit 3d transform to load the checkbox elements into memory so that swiches that start off offscreen are properly rendered when the container uses -webkit-overflow-scroll-touch.

This is a bug that seems to appear on iOS5
