### PR TITLE
Enable change event for originall input element

### DIFF
--- a/jquery/iphone-style-checkboxes.js
+++ b/jquery/iphone-style-checkboxes.js
@@ -114,6 +114,7 @@
       } else {
         this.elem.prop('checked', !this.elem.prop('checked'));
       }
+      this.elem.change();  // notice changing to original element
       iOSCheckbox.currentlyClicking = null;
       iOSCheckbox.dragging = null;
       return this.didChange();


### PR DESCRIPTION
Simplest solution to notice original input element when checkbox has changed status.
You can grab change event with jquery method $("element").change(...)
