### PR TITLE
Fixing little bug in coffee

### DIFF
--- a/coffee/iphone-style-checkboxes.coffee
+++ b/coffee/iphone-style-checkboxes.coffee
@@ -194,7 +194,7 @@ class iOSCheckbox
     @onDragMove(event, x)
     
   onGlobalUp: (event) ->
-    return unless iOSCheckbox.currentlyClicking
+    return if iOSCheckbox.currentlyClicking
     event.preventDefault()
 
     x = event.pageX || event.originalEvent.changedTouches[0].pageX


### PR DESCRIPTION
On our browser the button was switching back after it was set.
onDragEnd event was fired with onMouseDown on a mouse click
